### PR TITLE
feat: add midi

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "es2015",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ES2020",
+    "strict": true,
+    "checkJs": true,
+    "types": ["webmidi"]
+  },
+  "include": ["."]
+}

--- a/midi.js
+++ b/midi.js
@@ -1,0 +1,305 @@
+const STATUS_BYTE = 0xf0;
+const CHANNEL_BYTE = 0x0f;
+const DATA_BYTE = 0x7f;
+
+// Status byte values that indicate the different midi notes
+const StatusByte = {
+  NOTE_OFF: 0x80,
+  NOTE_ON: 0x90,
+  KEY_PRESSURE: 0xa0,
+  CC: 0xb0,
+  PROGRAM_CHANGE: 0xc0,
+  CHANNEL_PRESSURE: 0xd0,
+  PITCH_BEND: 0xe0,
+};
+
+// CC values that indicate special CC Modes.
+const CCModeValues = {
+  ALL_SOUNDS_OFF: 120,
+  RESET_ALL: 121,
+  LOCAL_CONTROLLER: 122,
+  ALL_NOTES_OFF: 123,
+  OMNI_OFF: 124,
+  OMNI_ON: 125,
+  MONO_ON: 126,
+  POLY_ON: 127,
+};
+
+/**
+ * @typedef {'denied'|'granted'|'uninitialized'|'unsupported'|'error'} AccessStatus
+ */
+
+/**
+ * @typedef MidiNote
+ * @property {number} status
+ * @property {number} channel
+ * @property {number} note
+ * @property {number} velocity
+ */
+
+/**
+ * Parse MIDI note on or off message.
+ *
+ * @param {Uint8Array} data
+ * @returns {MidiNote}
+ */
+function parseNote(data) {
+  return {
+    status: data[0] & CHANNEL_BYTE,
+    channel: data[0] & STATUS_BYTE,
+    note: data[1],
+    velocity: data[2] / 127,
+  };
+}
+
+class Midi {
+  /** @type {WebMidi.MIDIAccess|undefined} */
+  #midiAccess;
+
+  /** @type {AccessStatus} */
+  #accessStatus = "uninitialized";
+
+  /**
+   * Initialize on a user permission request
+   *
+   * @returns {Promise<AccessStatus>}
+   */
+  async requestAccess() {
+    if (this.#accessStatus !== "granted") {
+      await navigator
+        .requestMIDIAccess()
+        .then((midiAccess) => this.#onSuccess(midiAccess))
+        .catch((reason) => this.#onFailure(reason));
+    }
+    return this.#accessStatus;
+  }
+
+  /**
+   * Get a list of MIDI input devices.
+   *
+   * @returns {WebMidi.MIDIInput[]} A list of MIDI input devices.
+   */
+  getInputs() {
+    if (!this.#midiAccess) return [];
+    return [...this.#midiAccess.inputs.values()];
+  }
+
+  /**
+   * Get a list of MIDI output devices.
+   *
+   * @returns {WebMidi.MIDIOutput[]} A list of MIDI output devices.
+   */
+  getOutputs() {
+    if (!this.#midiAccess) return [];
+    return [...this.#midiAccess.outputs.values()];
+  }
+
+  get accessStatus() {
+    return this.#accessStatus;
+  }
+
+  /**
+   * @param {WebMidi.MIDIAccess} midiAccess - Successful MIDI access response object.
+   */
+  #onSuccess = (midiAccess) => {
+    this.#accessStatus = "granted";
+    this.#midiAccess = midiAccess;
+    console.log(`Midi: access granted`);
+  };
+
+  /**
+   *
+   * @param {any} reason - The reason for the MIDI access failure.
+   */
+  #onFailure = (reason) => {
+    if (reason instanceof DOMException) {
+      switch (reason.name) {
+        case "NotSupportedError":
+          this.#accessStatus = "unsupported";
+          break;
+        case "SecurityError":
+          this.#accessStatus = "denied";
+          break;
+        default:
+          this.#accessStatus = "error";
+      }
+    }
+    console.log(`Midi: access failed, reason: ${reason}`);
+  };
+}
+
+class MidiDevices {
+  /** @type {HTMLElement | null} */
+  #el;
+
+  /** @type {WebMidi.MIDIInput | null} */
+  #device = null;
+
+  #midi = new Midi();
+
+  constructor() {
+    this.#el = document.querySelector("#midi");
+  }
+
+  /**
+   * Request MIDI access from the user.
+   *
+   * Should be called on a user interaction, like a click event.
+   * @returns {void}
+   */
+  requestAccess() {
+    this.#midi
+      .requestAccess()
+      .then(() => this.showList())
+      .catch((error) => this.showError(error));
+  }
+
+  /**
+   * Use a MIDI device based on its id.
+   *
+   * @param {string} inputId
+   * @returns {void}
+   */
+  use(inputId) {
+    const input = this.#midi.getInputs().find(({ id }) => id === inputId);
+
+    if (!input) {
+      this.showError("Could not connect to MIDI device.");
+      return;
+    }
+
+    this.#device = input;
+
+    this.#device.onmidimessage = (e) => {
+      if (!this.connected()) return;
+      const data = e.data;
+      const status = data[0] & 0xf0;
+      // might want to parse other message types, so using a switch here.
+      switch (status) {
+        case StatusByte.NOTE_ON: {
+          PatchBankApp.turnOnNote(parseNote(data));
+          break;
+        }
+        case StatusByte.NOTE_OFF: {
+          PatchBankApp.turnOffNote(parseNote(data));
+          break;
+        }
+      }
+    };
+
+    this.showDevice();
+  }
+
+  /**
+   * Disconnect a MIDI device.
+   *
+   * @returns {void}
+   */
+  disconnect() {
+    this.#device = null;
+    this.showList();
+  }
+
+  /**
+   * Check if a MIDI device is connected.
+   *
+   * @returns {boolean}
+   */
+  connected() {
+    return this.getDevice() !== null;
+  }
+
+  /**
+   * Get the connected MIDI input device if connected.
+   *
+   * @returns {WebMidi.MIDIInput | null}
+   */
+  getDevice() {
+    if (!this.#device) return null;
+    if (this.#device.connection !== "open") return null;
+    return this.#device;
+  }
+
+  /**
+   * Show a button to request MIDI access.
+   *
+   * @returns {void}
+   */
+  showRequestAccess() {
+    if (!this.#el) return;
+    if (this.#midi.accessStatus === "granted") {
+      this.#el.innerHTML = /* html */ `
+        <button type="button" onclick="{MidiDevicesApp.showList();">
+          Use MIDI
+        </button>
+      `;
+    } else {
+      this.#el.innerHTML = /* html */ `
+        <button type="button" onclick="MidiDevicesApp.requestAccess();">
+          Use MIDI
+        </button>
+      `;
+    }
+  }
+
+  /**
+   * Show the list of possible MIDI input devices to connect.
+   *
+   * @returns {void}
+   */
+  showList() {
+    if (!this.#el || !(this.#midi.accessStatus === "granted")) return;
+
+    const devices = this.#midi.getInputs().map((input) => {
+      return /* html */ `
+        <li>
+          <button onclick="MidiDevicesApp.use('${input.id}');">
+            ${input.name || input.id}
+          </button>
+        </li>
+      `;
+    });
+
+    this.#el.innerHTML = /* html */ `
+      <ul>
+        ${devices.join(" ")}
+      </ul>
+    `;
+  }
+
+  /**
+   * Show the currently connected device
+   *
+   * @returns {void}
+   */
+  showDevice() {
+    if (!this.#el || !this.#device) return;
+
+    const device = this.#device;
+
+    this.#el.innerHTML = /* html */ `
+      <div>
+        <div>
+          Midi Device: ${device.name || device.id}
+          <button onclick="MidiDevicesApp.disconnect();">Disconnect</button>
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * Shows an error message.
+   *
+   * @param {string} message
+   * @returns {void}
+   */
+  showError(message) {
+    if (!this.#el) return;
+
+    this.#el.innerHTML = /* html */ `
+      <p>${message}</p>
+    `;
+  }
+}
+
+const MidiDevicesApp = new MidiDevices();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "plaits-editor",
+  "version": "1.0.0-alpha.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plaits-editor",
+      "version": "1.0.0-alpha.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/webmidi": "^2.0.6"
+      }
+    },
+    "node_modules/@types/webmidi": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.0.6.tgz",
+      "integrity": "sha512-sfS0A5IryqmBrUpcGPipEPeFdpqmZzP6b6lZFxHKgz5n2Vhzh4yJ5P2TvoDUhDjqJyv0Y25ng0Qodgo2Vu08ug==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@types/webmidi": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.0.6.tgz",
+      "integrity": "sha512-sfS0A5IryqmBrUpcGPipEPeFdpqmZzP6b6lZFxHKgz5n2Vhzh4yJ5P2TvoDUhDjqJyv0Y25ng0Qodgo2Vu08ug==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "plaits-editor",
+  "version": "1.0.0-alpha.1",
+  "private": true,
+  "description": "Editor for Mutable Instruments Plaits models.",
+  "devDependencies": {
+    "@types/webmidi": "2.0.6"
+  },
+  "license": "MIT"
+}

--- a/patch_bank.html
+++ b/patch_bank.html
@@ -31,6 +31,11 @@
           <li><input id="envelope" type="range" min="0" max="1" step="0.01" value="0.5" oninput="PatchBankApp.updateParams();"><label for="envelope">Envelope</label></li>
         </ul>
       </div>
+      <div id="midi">
+        <button type="button" onclick="MidiDevicesApp.requestAccess();">
+          Access MIDI
+        </button>
+      </div>
       <h3>Import DX7 patches</h3>
       <input type="file" id="syxFile" onchange="PatchBankApp.loadSYX(this);" accept=".syx,.raw" multiple>
       <div id="banks" class="banksWrap">
@@ -50,7 +55,7 @@
       <button type="button" onclick="PatchBankApp.download(true);">Download .syx</button>
     </div>
   </div>
-
+<script type="text/javascript" src="midi.js"></script>
 <script type="text/javascript" src="patch_bank.js"></script>
 
 </body>

--- a/patch_bank.js
+++ b/patch_bank.js
@@ -128,16 +128,18 @@ class PatchBank {
       element.dataset.index = patch.index;
       element.dataset.id = this.cleanName + '|' + patch.index;
       element.className = 'patchContainer';
-      element.addEventListener("mouseenter", function(e) {
+      element.addEventListener('click', function (e) {
         const synth = PatchBankApp.synthSource;
         if (synth) {
           synth.port.postMessage(['setPatch', patch.data]);
-          synth.parameters.get('gate').value = 1.0;
+          if (!MidiDevicesApp.connected()) {
+            synth.parameters.get('gate').value = 1.0;
+          }
         }
       });
       element.addEventListener("mouseleave", function(e) {
         const synth = PatchBankApp.synthSource;
-        if (synth) {
+        if (synth && !MidiDevicesApp.connected()) {
           synth.parameters.get('gate').value = 0.0;
         }
       });

--- a/style.css
+++ b/style.css
@@ -65,6 +65,10 @@ body {
   margin: 0px;
 }
 
+#midi ul li {
+  list-style: none;
+}
+
 a {
   font-weight: none;
   text-decoration: none;


### PR DESCRIPTION
I've been having a lot of fun with this. I just wanted to share some work I did to it.

I restructured everything so I could use TypeScript, and it's pretty half baked. But I really though the Patch Bank need to be MIDI controlled 😄.

I wanted to know if you though any of this looked interesting. I need to read through your code more to know how to integrate the MIDI controller. But it's kinda working right now. Check it out at https://johnhooks.io/plaits-editor/patch_bank.html

The majority of the source I added is in the `src` directory. I added an `update` method to `PatchBankApp` so it could be called `onmidimessage`. The gate is not being controlled right and I have an error coming up:

```
Uncaught TypeError: Failed to set the 'value' property on 'AudioParam': The provided float value is non-finite.
```

I must not be providing the right values to the synth. 

I'm planning on moving the code into TypeScript, also I'm thinking of using SvelteKit to simplify the structure of the UI.

Thanks for open sourcing this!