### PR TITLE
fix: Encoder constructor encoding.symbolDuration

### DIFF
--- a/encoder.js
+++ b/encoder.js
@@ -98,7 +98,7 @@ class Encoder {
     const fn = encoding.shape == 'cosine' ? Math.cos : Math.sin;
     const noDC = encoding.shape == 'sine_no_dc';
     for (let duration of encoding.symbolDurations) {
-      let gain = noDC ? Math.max(symbolDurations[0] / duration, 0.5) : 1.0;
+      let gain = noDC ? Math.max(encoding.symbolDurations[0] / duration, 0.5) : 1.0;
       let plus = new Float32Array(duration);
       let minus = new Float32Array(duration);
       for (let i = 0; i < duration; i++) {


### PR DESCRIPTION
I'm working to moving everything to TypeScript and it caught an error in the Encoder. `symbolDuration` wasn't defined, I think you mean `encoding.symbolDuration`.

Also, this is the branch I'm working on that moves everything to TypeScript:
https://github.com/johnhooks/plaits-editor/tree/experimental

I think it would help catch errors and make it more maintainable. At the moment, it's in a pretty incomplete state. I'm not a math wizard though, and I may have a lot of questions about what some of the function params types are. Would you be willing to answer questions I have as I work through it? Thanks!